### PR TITLE
Fix incorrectly named facade method

### DIFF
--- a/src/IM.php
+++ b/src/IM.php
@@ -10,7 +10,7 @@ class IM extends Facade{
    * Facade Acessor
    * @return [type] [description]
    */
-  protected static function getFacadeAcessor(){
+  protected static function getFacadeAccessor(){
     return 'IM';
   }
 


### PR DESCRIPTION
Fixes "Facade does not implement getFacadeAccessor method" issue in Laravel